### PR TITLE
Have default messages in all exceptions

### DIFF
--- a/src/Deserializers/Exceptions/DeserializationException.php
+++ b/src/Deserializers/Exceptions/DeserializationException.php
@@ -2,15 +2,22 @@
 
 namespace Deserializers\Exceptions;
 
+use Exception;
+use RuntimeException;
+
 /**
  * @since 1.0
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class DeserializationException extends \RuntimeException {
+class DeserializationException extends RuntimeException {
 
-	public function __construct( $message = '', \Exception $previous = null ) {
+	/**
+	 * @param string $message
+	 * @param Exception|null $previous
+	 */
+	public function __construct( $message = '', Exception $previous = null ) {
 		parent::__construct( $message, 0, $previous );
 	}
 

--- a/src/Deserializers/Exceptions/InvalidAttributeException.php
+++ b/src/Deserializers/Exceptions/InvalidAttributeException.php
@@ -9,6 +9,7 @@ use Exception;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class InvalidAttributeException extends DeserializationException {
 
@@ -29,6 +30,16 @@ class InvalidAttributeException extends DeserializationException {
 	) {
 		$this->attributeName = $attributeName;
 		$this->attributeValue = $attributeValue;
+
+		if ( $message === '' ) {
+			$message = 'Attribute "' . $attributeName . '"';
+
+			if ( is_scalar( $attributeValue ) ) {
+				$message .= ' with value "' . $attributeValue . '"';
+			}
+
+			$message .= ' is invalid';
+		}
 
 		parent::__construct( $message, $previous );
 	}

--- a/src/Deserializers/Exceptions/MissingAttributeException.php
+++ b/src/Deserializers/Exceptions/MissingAttributeException.php
@@ -9,6 +9,7 @@ use Exception;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class MissingAttributeException extends DeserializationException {
 
@@ -21,6 +22,10 @@ class MissingAttributeException extends DeserializationException {
 	 */
 	public function __construct( $attributeName, $message = '', Exception $previous = null ) {
 		$this->attributeName = $attributeName;
+
+		if ( $message === '' ) {
+			$message = 'Attribute "' . $attributeName . '" is missing';
+		}
 
 		parent::__construct( $message, $previous );
 	}

--- a/src/Deserializers/Exceptions/UnsupportedTypeException.php
+++ b/src/Deserializers/Exceptions/UnsupportedTypeException.php
@@ -11,18 +11,23 @@ use Exception;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class UnsupportedTypeException extends DeserializationException {
 
-	protected $unsupportedType;
+	protected $type;
 
 	/**
-	 * @param mixed $unsupportedType
+	 * @param mixed $type
 	 * @param string $message
 	 * @param Exception|null $previous
 	 */
-	public function __construct( $unsupportedType, $message = '', Exception $previous = null ) {
-		$this->unsupportedType = $unsupportedType;
+	public function __construct( $type, $message = '', Exception $previous = null ) {
+		$this->type = $type;
+
+		if ( $message === '' && is_scalar( $type ) ) {
+			$message = 'Type "' . $type . '" is unsupported';
+		}
 
 		parent::__construct( $message, $previous );
 	}
@@ -31,7 +36,7 @@ class UnsupportedTypeException extends DeserializationException {
 	 * @return mixed
 	 */
 	public function getUnsupportedType() {
-		return $this->unsupportedType;
+		return $this->type;
 	}
 
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/DeserializationExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/DeserializationExceptionTest.php
@@ -3,28 +3,31 @@
 namespace Deserializers\Tests\Phpunit\Exceptions;
 
 use Deserializers\Exceptions\DeserializationException;
+use Exception;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers Deserializers\Exceptions\DeserializationException
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
-class DeserializationExceptionTest extends \PHPUnit_Framework_TestCase {
+class DeserializationExceptionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorWithOnlyRequiredArguments() {
-		new DeserializationException();
-		$this->assertTrue( true );
+		$exception = new DeserializationException();
+
+		$this->assertSame( '', $exception->getMessage() );
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	public function testConstructorWithAllArguments() {
-		$message = 'NyanData all the way across the sky!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'previous' );
+		$exception = new DeserializationException( 'customMessage', $previous );
 
-		$exception = new DeserializationException( $message, $previous );
-
-		$this->assertEquals( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/InvalidAttributeExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/InvalidAttributeExceptionTest.php
@@ -3,40 +3,37 @@
 namespace Deserializers\Tests\Phpunit\Exceptions;
 
 use Deserializers\Exceptions\InvalidAttributeException;
+use Exception;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers Deserializers\Exceptions\InvalidAttributeException
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
-class InvalidAttributeExceptionTest extends \PHPUnit_Framework_TestCase {
+class InvalidAttributeExceptionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorWithOnlyRequiredArguments() {
-		$attributeName = 'theGame';
-		$attributeValue = 'youJustLostIt';
+		$exception = new InvalidAttributeException( 'attribute', 'value' );
 
-		$exception = new InvalidAttributeException( $attributeName, $attributeValue );
-
-		$this->assertRequiredFieldsAreSet( $exception, $attributeName, $attributeValue );
+		$this->assertSame( 'attribute', $exception->getAttributeName() );
+		$this->assertSame( 'value', $exception->getAttributeValue() );
+		$this->assertSame( 'Attribute "attribute" with value "value" is invalid',
+			$exception->getMessage() );
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	public function testConstructorWithAllArguments() {
-		$attributeName = 'theGame';
-		$attributeValue = 'youJustLostIt';
-		$message = 'NyanData all the way across the sky!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'previous' );
+		$exception = new InvalidAttributeException( 'attribute', 'value', 'customMessage',
+			$previous );
 
-		$exception = new InvalidAttributeException( $attributeName, $attributeValue, $message, $previous );
-
-		$this->assertRequiredFieldsAreSet( $exception, $attributeName, $attributeValue );
-		$this->assertEquals( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
-	}
-
-	protected function assertRequiredFieldsAreSet( InvalidAttributeException $exception, $attributeName, $attributeValue ) {
-		$this->assertEquals( $attributeName, $exception->getAttributeName() );
-		$this->assertEquals( $attributeValue, $exception->getAttributeValue() );
+		$this->assertSame( 'attribute', $exception->getAttributeName() );
+		$this->assertSame( 'value', $exception->getAttributeValue() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/MissingAttributeExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/MissingAttributeExceptionTest.php
@@ -3,37 +3,33 @@
 namespace Deserializers\Tests\Phpunit\Exceptions;
 
 use Deserializers\Exceptions\MissingAttributeException;
+use Exception;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers Deserializers\Exceptions\MissingAttributeException
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
-class MissingAttributeExceptionTest extends \PHPUnit_Framework_TestCase {
+class MissingAttributeExceptionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorWithOnlyRequiredArguments() {
-		$attributeName = 'theGame';
+		$exception = new MissingAttributeException( 'attribute' );
 
-		$exception = new MissingAttributeException( $attributeName );
-
-		$this->assertRequiredFieldsAreSet( $exception, $attributeName );
+		$this->assertSame( 'attribute', $exception->getAttributeName() );
+		$this->assertSame( 'Attribute "attribute" is missing', $exception->getMessage() );
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	public function testConstructorWithAllArguments() {
-		$attributeName = 'theGame';
-		$message = 'NyanData all the way across the sky!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'previous' );
+		$exception = new MissingAttributeException( 'attribute', 'customMessage', $previous );
 
-		$exception = new MissingAttributeException( $attributeName, $message, $previous );
-
-		$this->assertRequiredFieldsAreSet( $exception, $attributeName );
-		$this->assertEquals( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
-	}
-
-	protected function assertRequiredFieldsAreSet( MissingAttributeException $exception, $attributeName ) {
-		$this->assertEquals( $attributeName, $exception->getAttributeName() );
+		$this->assertSame( 'attribute', $exception->getAttributeName() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/MissingTypeExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/MissingTypeExceptionTest.php
@@ -3,28 +3,31 @@
 namespace Deserializers\Tests\Phpunit\Exceptions;
 
 use Deserializers\Exceptions\MissingTypeException;
+use Exception;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers Deserializers\Exceptions\MissingTypeException
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
-class MissingTypeExceptionTest extends \PHPUnit_Framework_TestCase {
+class MissingTypeExceptionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorWithOnlyRequiredArguments() {
-		new MissingTypeException();
-		$this->assertTrue( true );
+		$exception = new MissingTypeException();
+
+		$this->assertSame( '', $exception->getMessage() );
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	public function testConstructorWithAllArguments() {
-		$message = 'NyanData all the way across the sky!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'previous' );
+		$exception = new MissingTypeException( 'customMessage', $previous );
 
-		$exception = new MissingTypeException( $message, $previous );
-
-		$this->assertEquals( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/UnsupportedTypeExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/UnsupportedTypeExceptionTest.php
@@ -3,37 +3,33 @@
 namespace Deserializers\Tests\Phpunit\Exceptions;
 
 use Deserializers\Exceptions\UnsupportedTypeException;
+use Exception;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @covers Deserializers\Exceptions\UnsupportedTypeException
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
-class UnsupportedTypeExceptionTest extends \PHPUnit_Framework_TestCase {
+class UnsupportedTypeExceptionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorWithOnlyRequiredArguments() {
-		$unsupportedType = 'fooBarBaz';
+		$exception = new UnsupportedTypeException( 'type' );
 
-		$exception = new UnsupportedTypeException( $unsupportedType );
-
-		$this->assertRequiredFieldsAreSet( $exception, $unsupportedType );
+		$this->assertSame( 'type', $exception->getUnsupportedType() );
+		$this->assertSame( 'Type "type" is unsupported', $exception->getMessage() );
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	public function testConstructorWithAllArguments() {
-		$unsupportedType = 'fooBarBaz';
-		$message = 'NyanData all the way across the sky!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'previous' );
+		$exception = new UnsupportedTypeException( 'type', 'customMessage', $previous );
 
-		$exception = new UnsupportedTypeException( $unsupportedType, $message, $previous );
-
-		$this->assertRequiredFieldsAreSet( $exception, $unsupportedType );
-		$this->assertEquals( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
-	}
-
-	protected function assertRequiredFieldsAreSet( UnsupportedTypeException $exception, $unsupportedType ) {
-		$this->assertEquals( $unsupportedType, $exception->getUnsupportedType() );
+		$this->assertSame( 'type', $exception->getUnsupportedType() );
+		$this->assertSame( 'customMessage', $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 }


### PR DESCRIPTION
I realized all these exceptions do have empty messages, even if there is additional information to construct a meaningful message. I found this is an issue while playing around with the EntityChangeTest in Wikibase.git.