### PR TITLE
Release 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,27 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
-### 4.0.0 (2017-08-13)
+### 4.0.0 (2017-10-24)
 
 * Removed the `Serialization_VERSION` constant.
-* Removed `StrategicDeserializer` along with the abstract `TypedDeserializationStrategy` base class.
+* Removed underspecified `StrategicDeserializer` along with the abstract
+  `TypedDeserializationStrategy` base class.
 * Removed undocumented `TypedObjectDeserializer::requireAttributes`.
-* Declared various protected properties and methods private.
+* Declared various protected properties and methods private:
+	* `DispatchingDeserializer::$deserializers`
+	* `DispatchingDeserializer::assertAreDeserializers`
+	* `DispatchingSerializer::$serializers`
+	* `DispatchingSerializer::assertAreSerializers`
+	* `InvalidAttributeException::$attributeName`
+	* `InvalidAttributeException::$attributeValue`
+	* `MissingAttributeException::$attributeName`
+	* `TypedObjectDeserializer::$objectType`
+	* `UnsupportedObjectException::$unsupportedObject`
+	* `UnsupportedTypeException::$unsupportedType`
+* Deprecated pure utility functions on `TypedObjectDeserializer`:
+	* `assertAttributeInternalType`
+	* `assertAttributeIsArray`
+	* `requireAttribute`
 * Added default messages to `InvalidAttributeException`, `MissingAttributeException`, and
   `UnsupportedTypeException`.
 * Added documentation to the `Serializer` and `Deserializer` interfaces.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 ## Release notes
 
-### 4.0.0 (2017-10-24)
+### 4.0.0 (2017-10-25)
 
 * Removed the `Serialization_VERSION` constant.
 * Removed underspecified `StrategicDeserializer` along with the abstract

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
-		"wikibase/wikibase-codesniffer": "^0.1.0"
+		"wikibase/wikibase-codesniffer": "^0.2.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Serialization">
+<ruleset>
 	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
 	<file>.</file>

--- a/src/Deserializers/TypedObjectDeserializer.php
+++ b/src/Deserializers/TypedObjectDeserializer.php
@@ -32,7 +32,6 @@ abstract class TypedObjectDeserializer implements DispatchableDeserializer {
 	public function __construct( $objectType, $typeKey = 'objectType' ) {
 		$this->objectType = $objectType;
 		$this->typeKey = $typeKey;
-
 	}
 
 	protected function assertCanDeserialize( $serialization ) {
@@ -49,7 +48,7 @@ abstract class TypedObjectDeserializer implements DispatchableDeserializer {
 		return $this->hasObjectType( $serialization ) && $this->hasCorrectObjectType( $serialization );
 	}
 
-	private function hasCorrectObjectType( $serialization ) {
+	private function hasCorrectObjectType( array $serialization ) {
 		return $serialization[$this->typeKey] === $this->objectType;
 	}
 
@@ -58,6 +57,13 @@ abstract class TypedObjectDeserializer implements DispatchableDeserializer {
 			&& array_key_exists( $this->typeKey, $serialization );
 	}
 
+	/**
+	 * @deprecated since 4.0, just do your own "if ( array_key_exists( … ) )" or
+	 *  "if ( isset( … ) )" instead
+	 *
+	 * @param array $array
+	 * @param string $attributeName
+	 */
 	protected function requireAttribute( array $array, $attributeName ) {
 		if ( !array_key_exists( $attributeName, $array ) ) {
 			throw new MissingAttributeException(
@@ -66,10 +72,23 @@ abstract class TypedObjectDeserializer implements DispatchableDeserializer {
 		}
 	}
 
+	/**
+	 * @deprecated since 4.0, just do your own "if ( is_array( … ) )" instead
+	 *
+	 * @param array $array
+	 * @param string $attributeName
+	 */
 	protected function assertAttributeIsArray( array $array, $attributeName ) {
 		$this->assertAttributeInternalType( $array, $attributeName, 'array' );
 	}
 
+	/**
+	 * @deprecated since 4.0, just do your own "if ( is_string( … ) )" and such instead
+	 *
+	 * @param array $array
+	 * @param string $attributeName
+	 * @param string $internalType
+	 */
 	protected function assertAttributeInternalType( array $array, $attributeName, $internalType ) {
 		if ( gettype( $array[$attributeName] ) !== $internalType ) {
 			throw new InvalidAttributeException(

--- a/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
+++ b/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
@@ -2,7 +2,10 @@
 
 namespace Deserializers\Tests\Phpunit\Deserializers;
 
+use Deserializers\DispatchableDeserializer;
 use Deserializers\DispatchingDeserializer;
+use Deserializers\Exceptions\DeserializationException;
+use InvalidArgumentException;
 
 /**
  * @covers Deserializers\DispatchingDeserializer
@@ -18,12 +21,12 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testCannotConstructWithNonDeserializers() {
-		$this->setExpectedException( 'InvalidArgumentException' );
+		$this->setExpectedException( InvalidArgumentException::class );
 		new DispatchingDeserializer( [ 42, 'foobar' ] );
 	}
 
 	public function testCanDeserialize() {
-		$subDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer->expects( $this->exactly( 4 ) )
 			->method( 'isDeserializerFor' )
@@ -40,7 +43,7 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testDeserializeWithDeserializableValues() {
-		$subDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'isDeserializerFor' )
@@ -57,7 +60,7 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSerializeWithUnserializableValue() {
-		$subDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer->expects( $this->once() )
 			->method( 'isDeserializerFor' )
@@ -65,12 +68,12 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 
 		$serializer = new DispatchingDeSerializer( [ $subDeserializer ] );
 
-		$this->setExpectedException( 'Deserializers\Exceptions\DeserializationException' );
+		$this->setExpectedException( DeserializationException::class );
 		$serializer->deserialize( 0 );
 	}
 
 	public function testSerializeWithMultipleSubSerializers() {
-		$subDeserializer0 = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer0 = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer0->expects( $this->any() )
 			->method( 'isDeserializerFor' )
@@ -80,7 +83,7 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'deserialize' )
 			->will( $this->returnValue( 42 ) );
 
-		$subDeserializer1 = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer1 = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer1->expects( $this->any() )
 			->method( 'isDeserializerFor' )
@@ -100,7 +103,7 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 	public function testAddSerializer() {
 		$deserializer = new DispatchingDeserializer( [] );
 
-		$subDeserializer = $this->getMock( 'Deserializers\DispatchableDeserializer' );
+		$subDeserializer = $this->getMock( DispatchableDeserializer::class );
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'isDeserializerFor' )

--- a/test/Deserializers/Tests/Phpunit/TypedObjectDeserializerTest.php
+++ b/test/Deserializers/Tests/Phpunit/TypedObjectDeserializerTest.php
@@ -26,7 +26,7 @@ class TypedObjectDeserializerTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function newMockDeserializer( $typeKey = self::DEFAULT_TYPE_KEY ) {
 		return $this->getMockForAbstractClass(
-			'Deserializers\TypedObjectDeserializer',
+			TypedObjectDeserializer::class,
 			[
 				self::DUMMY_TYPE_VALUE,
 				$typeKey

--- a/test/Serializers/Tests/Phpunit/DispatchingSerializerTest.php
+++ b/test/Serializers/Tests/Phpunit/DispatchingSerializerTest.php
@@ -2,7 +2,10 @@
 
 namespace Serializers\Tests\Phpunit\Serializers;
 
+use InvalidArgumentException;
+use Serializers\DispatchableSerializer;
 use Serializers\DispatchingSerializer;
+use Serializers\Exceptions\UnsupportedObjectException;
 
 /**
  * @covers Serializers\DispatchingSerializer
@@ -20,18 +23,18 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $serializer->isSerializerFor( 'foo' ) );
 		$this->assertFalse( $serializer->isSerializerFor( null ) );
 
-		$this->setExpectedException( 'Serializers\Exceptions\UnsupportedObjectException' );
+		$this->setExpectedException( UnsupportedObjectException::class );
 
 		$serializer->serialize( 'foo' );
 	}
 
 	public function testConstructWithInvalidArgumentsCausesException() {
-		$this->setExpectedException( 'InvalidArgumentException' );
+		$this->setExpectedException( InvalidArgumentException::class );
 		new DispatchingSerializer( [ new \stdClass() ] );
 	}
 
 	public function testCanSerialize() {
-		$subSerializer = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer->expects( $this->exactly( 4 ) )
 			->method( 'isSerializerFor' )
@@ -48,7 +51,7 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSerializeWithSerializableValues() {
-		$subSerializer = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer->expects( $this->any() )
 			->method( 'isSerializerFor' )
@@ -65,7 +68,7 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testSerializeWithUnserializableValue() {
-		$subSerializer = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer->expects( $this->once() )
 			->method( 'isSerializerFor' )
@@ -73,12 +76,12 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 
 		$serializer = new DispatchingSerializer( [ $subSerializer ] );
 
-		$this->setExpectedException( 'Serializers\Exceptions\UnsupportedObjectException' );
+		$this->setExpectedException( UnsupportedObjectException::class );
 		$serializer->serialize( 0 );
 	}
 
 	public function testSerializeWithMultipleSubSerializers() {
-		$subSerializer0 = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer0 = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer0->expects( $this->any() )
 			->method( 'isSerializerFor' )
@@ -88,7 +91,7 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'serialize' )
 			->will( $this->returnValue( 42 ) );
 
-		$subSerializer1 = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer1 = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer1->expects( $this->any() )
 			->method( 'isSerializerFor' )
@@ -104,7 +107,7 @@ class DispatchingSerializerTest extends \PHPUnit_Framework_TestCase {
 	public function testAddSerializer() {
 		$serializer = new DispatchingSerializer( [] );
 
-		$subSerializer = $this->getMock( 'Serializers\DispatchableSerializer' );
+		$subSerializer = $this->getMock( DispatchableSerializer::class );
 
 		$subSerializer->expects( $this->any() )
 			->method( 'isSerializerFor' )


### PR DESCRIPTION
I carefully reviewed each individual change in this release again, and I'm certain this really is the best way to go:
* I find the `StrategicDeserializer` very much underspecified. What is a "strategy" anyway? If a project really needs something like this, it's quite trivial to implement it there. But as far as I can tell this is not used in any active project any more. I find a usage in https://github.com/wmde/AskSerialization, but this is a dead project.
* The `TypedObjectDeserializer` methods I'm deprecating here are pure utility functions. They have nothing to do with what the base class represents. They neither access the class' properties, nor are they called by one of the methods that define this class. The only reason these utility functions are on this abstract base class is code sharing. We do have utility functions with the same names in some other classes, but they are private everywhere, except here.

The latest release is 3 years old. It's time.

[Bug: T173225](https://phabricator.wikimedia.org/T173225)