### PR TITLE
Fix class name

### DIFF
--- a/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
+++ b/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
@@ -66,7 +66,7 @@ class DispatchingDeserializerTest extends \PHPUnit_Framework_TestCase {
 			->method( 'isDeserializerFor' )
 			->will( $this->returnValue( false ) );
 
-		$serializer = new DispatchingDeSerializer( [ $subDeserializer ] );
+		$serializer = new DispatchingDeserializer( [ $subDeserializer ] );
 
 		$this->setExpectedException( DeserializationException::class );
 		$serializer->deserialize( 0 );


### PR DESCRIPTION
This was the only occurrence of “DeSerializer” with an uppercase S, and it showed up in a CI failure in #23; class names are supposed to be case insensitive, but let’s fix it anyways (makes it easier to find uses of the class with e. g. `git grep`) and see if that also resolves the CI problem.