### PR TITLE
Stop supporting HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script: composer install --prefer-source
 
 script: composer test
 
 after_success:
-  - if [[ "`phpenv version-name`" != "7.1" ]]; then exit 0; fi
+  - if [[ "`phpenv version-name`" != "7.4" ]]; then exit 0; fi
   - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Also contains various Exceptions and a few basic (de)serialization utilities.
 
 ## Requirements
 
-* PHP 5.5 or later
+* PHP 7.0 or later
 
 ## Installation
 
@@ -86,6 +86,11 @@ Serialization has been written by [Jeroen De Dauw](https://www.mediawiki.org/wik
 as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
+
+### 5.0.0 (2020-03-18)
+
+* Updated minimal required PHP version from 5.5.9 to 7.0.
+  In particular, HHVM is no longer supported.
 
 ### 4.0.0 (2017-10-25)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.5.9"
+		"php": ">=7.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",


### PR DESCRIPTION
The HHVM build on Travis CI has been broken since at least November 2018, and Wikimedia hasn’t used HHVM for a while now, so let’s just stop supporting it. This constitutes a breaking change, so bump the major version number.

While we’re at it, let’s also start testing on *newer* PHP versions in Travis, and use the newest one for the coverage analysis (though to be honest I have no clue if that setup still works).

---

This probably isn’t complete, it just kinda grew out of hand… the last major release deprecated some things, should we remove those now if we’re doing another major release?