### PR TITLE
Remove deprecated functions for 5.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 
 * Updated minimal required PHP version from 5.5.9 to 7.0.
   In particular, HHVM is no longer supported.
+* Removed pure utility functions on `TypedObjectDeserializer` (deprecated in 4.0.0):
+	* `assertAttributeInternalType`
+	* `assertAttributeIsArray`
+	* `requireAttribute`
 
 ### 4.0.0 (2017-10-25)
 

--- a/src/Deserializers/TypedObjectDeserializer.php
+++ b/src/Deserializers/TypedObjectDeserializer.php
@@ -57,46 +57,4 @@ abstract class TypedObjectDeserializer implements DispatchableDeserializer {
 			&& array_key_exists( $this->typeKey, $serialization );
 	}
 
-	/**
-	 * @deprecated since 4.0, just do your own "if ( array_key_exists( … ) )" or
-	 *  "if ( isset( … ) )" instead
-	 *
-	 * @param array $array
-	 * @param string $attributeName
-	 */
-	protected function requireAttribute( array $array, $attributeName ) {
-		if ( !array_key_exists( $attributeName, $array ) ) {
-			throw new MissingAttributeException(
-				$attributeName
-			);
-		}
-	}
-
-	/**
-	 * @deprecated since 4.0, just do your own "if ( is_array( … ) )" instead
-	 *
-	 * @param array $array
-	 * @param string $attributeName
-	 */
-	protected function assertAttributeIsArray( array $array, $attributeName ) {
-		$this->assertAttributeInternalType( $array, $attributeName, 'array' );
-	}
-
-	/**
-	 * @deprecated since 4.0, just do your own "if ( is_string( … ) )" and such instead
-	 *
-	 * @param array $array
-	 * @param string $attributeName
-	 * @param string $internalType
-	 */
-	protected function assertAttributeInternalType( array $array, $attributeName, $internalType ) {
-		if ( gettype( $array[$attributeName] ) !== $internalType ) {
-			throw new InvalidAttributeException(
-				$attributeName,
-				$array[$attributeName],
-				"The internal type of attribute '$attributeName'  needs to be '$internalType'"
-			);
-		}
-	}
-
 }


### PR DESCRIPTION
These were already deprecated in 4.0.0, so let’s completely remove them with the next major version.