### PR TITLE
Drop PHP 7.0 and PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",


### PR DESCRIPTION
These versions are no longer supported by MediaWiki, Wikibase or PHP itself. Also, they are blocking #28.

This currently keeps PHP 7.2 as Wikimedia production is still on PHP 7.2 and will need a bit more time to change: https://phabricator.wikimedia.org/T257879#6339607

Depending on how one wants to look at it, this might be seen as a breaking change that requires a new major version release? That would seem to be related to the discussion in #27, the result of which isn't entirely clear to me.