### PR TITLE
Add default message to MissingTypeException

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ as [Wikimedia Germany](https://wikimedia.de) employee for the [Wikidata project]
 * Type hinted the `$previous` parameter as `Throwable` instead of `Exception`
 * Updated minimum required PHP version from `5.5.9` to `7.2` (HHVM is no longer supported)
 * Updated to `GPL-2.0-or-later` according to SPDX v3
+* Added a default message to the MissingTypeException
 
 ### 4.0.0 (2017-10-25)
 

--- a/src/Deserializers/Exceptions/MissingTypeException.php
+++ b/src/Deserializers/Exceptions/MissingTypeException.php
@@ -14,10 +14,7 @@ use Throwable;
  */
 class MissingTypeException extends DeserializationException {
 
-	public function __construct( $message = '', Throwable $previous = null ) {
-		if ( $message === '' ) {
-			$message = 'Type is missing';
-		}
+	public function __construct( string $message = 'Type is missing', Throwable $previous = null ) {
 		parent::__construct( $message, $previous );
 	}
 }

--- a/src/Deserializers/Exceptions/MissingTypeException.php
+++ b/src/Deserializers/Exceptions/MissingTypeException.php
@@ -12,10 +12,10 @@ namespace Deserializers\Exceptions;
  */
 class MissingTypeException extends DeserializationException {
 
-  public function __construct( $message = '', \Exception $previous = null ) {
-    if ( $message === '' ) {
-      $message = 'Type is missing';
-    }
+	public function __construct( $message = '', \Exception $previous = null ) {
+		if ( $message === '' ) {
+			$message = 'Type is missing';
+		}
 		parent::__construct( $message, $previous );
 	}
 }

--- a/src/Deserializers/Exceptions/MissingTypeException.php
+++ b/src/Deserializers/Exceptions/MissingTypeException.php
@@ -2,6 +2,8 @@
 
 namespace Deserializers\Exceptions;
 
+use Throwable;
+
 /**
  * Indicates the objectType key is missing in the serialization.
  *
@@ -12,7 +14,7 @@ namespace Deserializers\Exceptions;
  */
 class MissingTypeException extends DeserializationException {
 
-	public function __construct( $message = '', \Exception $previous = null ) {
+	public function __construct( $message = '', Throwable $previous = null ) {
 		if ( $message === '' ) {
 			$message = 'Type is missing';
 		}

--- a/src/Deserializers/Exceptions/MissingTypeException.php
+++ b/src/Deserializers/Exceptions/MissingTypeException.php
@@ -12,4 +12,10 @@ namespace Deserializers\Exceptions;
  */
 class MissingTypeException extends DeserializationException {
 
+  public function __construct( $message = '', \Exception $previous = null ) {
+    if ( $message === '' ) {
+      $message = 'Type is missing';
+    }
+		parent::__construct( $message, $previous );
+	}
 }

--- a/test/Deserializers/Tests/Phpunit/Exceptions/MissingTypeExceptionTest.php
+++ b/test/Deserializers/Tests/Phpunit/Exceptions/MissingTypeExceptionTest.php
@@ -18,7 +18,7 @@ class MissingTypeExceptionTest extends \PHPUnit\Framework\TestCase {
 	public function testConstructorWithOnlyRequiredArguments() {
 		$exception = new MissingTypeException();
 
-		$this->assertSame( '', $exception->getMessage() );
+		$this->assertSame( 'Type is missing', $exception->getMessage() );
 		$this->assertNull( $exception->getPrevious() );
 	}
 


### PR DESCRIPTION
This makes it consistent with the other Exceptions that also have some default message.

That exception message is currently used in the API response.

Bug: LeMyst/WikibaseIntegrator#294