### PR TITLE
Support mediawiki-codesniffer@45.0.0, PHP 8.4 readiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 dist: xenial
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
   - 8.0
 

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5.14",
-		"mediawiki/mediawiki-codesniffer": "34.0.0"
+		"mediawiki/mediawiki-codesniffer": "^45"
 	},
 	"autoload": {
 		"psr-4": {
@@ -48,5 +48,10 @@
 			"phpcs -p -s",
 			"phpunit"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/Deserializers/Exceptions/DeserializationException.php
+++ b/src/Deserializers/Exceptions/DeserializationException.php
@@ -17,7 +17,7 @@ class DeserializationException extends RuntimeException {
 	 * @param string $message
 	 * @param Throwable|null $previous
 	 */
-	public function __construct( $message = '', Throwable $previous = null ) {
+	public function __construct( $message = '', ?Throwable $previous = null ) {
 		parent::__construct( $message, 0, $previous );
 	}
 

--- a/src/Deserializers/Exceptions/InvalidAttributeException.php
+++ b/src/Deserializers/Exceptions/InvalidAttributeException.php
@@ -29,7 +29,7 @@ class InvalidAttributeException extends DeserializationException {
 		$attributeName,
 		$attributeValue,
 		$message = '',
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		$this->attributeName = $attributeName;
 		$this->attributeValue = $attributeValue;

--- a/src/Deserializers/Exceptions/MissingAttributeException.php
+++ b/src/Deserializers/Exceptions/MissingAttributeException.php
@@ -22,7 +22,7 @@ class MissingAttributeException extends DeserializationException {
 	 * @param string $message
 	 * @param Throwable|null $previous
 	 */
-	public function __construct( $attributeName, $message = '', Throwable $previous = null ) {
+	public function __construct( $attributeName, $message = '', ?Throwable $previous = null ) {
 		$this->attributeName = $attributeName;
 
 		if ( $message === '' ) {

--- a/src/Deserializers/Exceptions/MissingTypeException.php
+++ b/src/Deserializers/Exceptions/MissingTypeException.php
@@ -14,7 +14,7 @@ use Throwable;
  */
 class MissingTypeException extends DeserializationException {
 
-	public function __construct( string $message = 'Type is missing', Throwable $previous = null ) {
+	public function __construct( string $message = 'Type is missing', ?Throwable $previous = null ) {
 		parent::__construct( $message, $previous );
 	}
 }

--- a/src/Deserializers/Exceptions/UnsupportedTypeException.php
+++ b/src/Deserializers/Exceptions/UnsupportedTypeException.php
@@ -22,7 +22,7 @@ class UnsupportedTypeException extends DeserializationException {
 	 * @param string $message
 	 * @param Throwable|null $previous
 	 */
-	public function __construct( $type, $message = '', Throwable $previous = null ) {
+	public function __construct( $type, $message = '', ?Throwable $previous = null ) {
 		$this->type = $type;
 
 		if ( $message === '' && is_scalar( $type ) ) {

--- a/src/Serializers/Exceptions/SerializationException.php
+++ b/src/Serializers/Exceptions/SerializationException.php
@@ -13,7 +13,7 @@ use Throwable;
  */
 class SerializationException extends RuntimeException {
 
-	public function __construct( $message = '', Throwable $previous = null ) {
+	public function __construct( $message = '', ?Throwable $previous = null ) {
 		parent::__construct( $message, 0, $previous );
 	}
 

--- a/src/Serializers/Exceptions/UnsupportedObjectException.php
+++ b/src/Serializers/Exceptions/UnsupportedObjectException.php
@@ -19,7 +19,7 @@ class UnsupportedObjectException extends SerializationException {
 	 * @param string $message
 	 * @param Throwable|null $previous
 	 */
-	public function __construct( $unsupportedObject, $message = '', Throwable $previous = null ) {
+	public function __construct( $unsupportedObject, $message = '', ?Throwable $previous = null ) {
 		$this->unsupportedObject = $unsupportedObject;
 
 		parent::__construct( $message, $previous );

--- a/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
+++ b/test/Deserializers/Tests/Phpunit/DispatchingDeserializerTest.php
@@ -30,9 +30,9 @@ class DispatchingDeserializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subDeserializer->expects( $this->exactly( 4 ) )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnCallback( function ( $value ) {
+			->willReturnCallback( static function ( $value ) {
 				return $value > 9000;
-			} ) );
+			} );
 
 		$serializer = new DispatchingDeserializer( [ $subDeserializer ] );
 
@@ -47,11 +47,11 @@ class DispatchingDeserializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'deserialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$serializer = new DispatchingDeserializer( [ $subDeserializer ] );
 
@@ -64,7 +64,7 @@ class DispatchingDeserializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subDeserializer->expects( $this->once() )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnValue( false ) );
+			->willReturn( false );
 
 		$serializer = new DispatchingDeserializer( [ $subDeserializer ] );
 
@@ -77,17 +77,17 @@ class DispatchingDeserializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subDeserializer0->expects( $this->any() )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subDeserializer0->expects( $this->any() )
 			->method( 'deserialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$subDeserializer1 = $this->createMock( DispatchableDeserializer::class );
 
 		$subDeserializer1->expects( $this->any() )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnValue( false ) );
+			->willReturn( false );
 
 		$subDeserializer2 = clone $subDeserializer1;
 
@@ -107,11 +107,11 @@ class DispatchingDeserializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'isDeserializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subDeserializer->expects( $this->any() )
 			->method( 'deserialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$deserializer->addDeserializer( $subDeserializer );
 

--- a/test/Serializers/Tests/Phpunit/DispatchingSerializerTest.php
+++ b/test/Serializers/Tests/Phpunit/DispatchingSerializerTest.php
@@ -38,9 +38,9 @@ class DispatchingSerializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subSerializer->expects( $this->exactly( 4 ) )
 			->method( 'isSerializerFor' )
-			->will( $this->returnCallback( function ( $value ) {
+			->willReturnCallback( static function ( $value ) {
 				return $value > 9000;
-			} ) );
+			} );
 
 		$serializer = new DispatchingSerializer( [ $subSerializer ] );
 
@@ -55,11 +55,11 @@ class DispatchingSerializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subSerializer->expects( $this->any() )
 			->method( 'isSerializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subSerializer->expects( $this->any() )
 			->method( 'serialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$serializer = new DispatchingSerializer( [ $subSerializer ] );
 
@@ -72,7 +72,7 @@ class DispatchingSerializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subSerializer->expects( $this->once() )
 			->method( 'isSerializerFor' )
-			->will( $this->returnValue( false ) );
+			->willReturn( false );
 
 		$serializer = new DispatchingSerializer( [ $subSerializer ] );
 
@@ -85,17 +85,17 @@ class DispatchingSerializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subSerializer0->expects( $this->any() )
 			->method( 'isSerializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subSerializer0->expects( $this->any() )
 			->method( 'serialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$subSerializer1 = $this->createMock( DispatchableSerializer::class );
 
 		$subSerializer1->expects( $this->any() )
 			->method( 'isSerializerFor' )
-			->will( $this->returnValue( false ) );
+			->willReturn( false );
 
 		$subSerializer2 = clone $subSerializer1;
 
@@ -111,11 +111,11 @@ class DispatchingSerializerTest extends \PHPUnit\Framework\TestCase {
 
 		$subSerializer->expects( $this->any() )
 			->method( 'isSerializerFor' )
-			->will( $this->returnValue( true ) );
+			->willReturn( true );
 
 		$subSerializer->expects( $this->any() )
 			->method( 'serialize' )
-			->will( $this->returnValue( 42 ) );
+			->willReturn( 42 );
 
 		$serializer->addSerializer( $subSerializer );
 


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. It should be upgraded to the latest version.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Bug: T379481