### PR TITLE
Upgrade to PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.5.14",
+		"phpunit/phpunit": "^9",
 		"mediawiki/mediawiki-codesniffer": "^45"
 	},
 	"autoload": {


### PR DESCRIPTION
According to 25e020e4e5, we were previously on PHPUnit 8 only for compatibility with PHP 7.2, which is no longer a concern.